### PR TITLE
Wrap GIR section in container and adjust heading style

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,45 +112,47 @@
             </div>
         </div>
 
-        <section class="section gir">
+        <section class="stage section gir">
             <h2>General Institute Requirements</h2>
-            <div class="gir-row section-row">
-                <div class="gir-block section-block">
-                    <h3>Science Core</h3>
-                    <div class="board gir-board">
-                        <div class="grid" id="gir-science"></div>
+            <div class="board gir-container">
+                <div class="gir-row section-row">
+                    <div class="gir-block section-block">
+                        <h3>Science Core</h3>
+                        <div class="board gir-board">
+                            <div class="grid" id="gir-science"></div>
+                        </div>
+                    </div>
+                    <div class="gir-block section-block">
+                        <h3>HASS</h3>
+                        <div class="board gir-board">
+                            <div class="grid" id="gir-hass"></div>
+                        </div>
                     </div>
                 </div>
-                <div class="gir-block section-block">
-                    <h3>HASS</h3>
-                    <div class="board gir-board">
-                        <div class="grid" id="gir-hass"></div>
+                <div class="gir-row section-row">
+                    <div class="gir-block section-block">
+                        <h3>Communication</h3>
+                        <div class="board gir-board">
+                            <div class="grid" id="gir-communication"></div>
+                        </div>
                     </div>
-                </div>
-            </div>
-            <div class="gir-row section-row">
-                <div class="gir-block section-block">
-                    <h3>Communication</h3>
-                    <div class="board gir-board">
-                        <div class="grid" id="gir-communication"></div>
+                    <div class="gir-block section-block">
+                        <h3>Laboratory</h3>
+                        <div class="board gir-board">
+                            <div class="grid" id="gir-lab"></div>
+                        </div>
                     </div>
-                </div>
-                <div class="gir-block section-block">
-                    <h3>Laboratory</h3>
-                    <div class="board gir-board">
-                        <div class="grid" id="gir-lab"></div>
+                    <div class="gir-block section-block">
+                        <h3>Physical Education</h3>
+                        <div class="board gir-board">
+                            <div class="grid" id="gir-pe"></div>
+                        </div>
                     </div>
-                </div>
-                <div class="gir-block section-block">
-                    <h3>Physical Education</h3>
-                    <div class="board gir-board">
-                        <div class="grid" id="gir-pe"></div>
-                    </div>
-                </div>
-                <div class="gir-block section-block">
-                    <h3>REST</h3>
-                    <div class="board gir-board">
-                        <div class="grid" id="gir-rest"></div>
+                    <div class="gir-block section-block">
+                        <h3>REST</h3>
+                        <div class="board gir-board">
+                            <div class="grid" id="gir-rest"></div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -343,7 +343,16 @@
     }
     function layout(gridEl, tierData) {
         gridEl.innerHTML = "";
-        gridEl.style.gridTemplateColumns = `repeat(${tierData.length}, 1fr)`;
+
+        const isGir = gridEl.closest(".gir-board");
+        if (isGir) {
+            gridEl.style.gridTemplateColumns = `repeat(${tierData.length}, minmax(150px, 1fr))`;
+            gridEl.style.width = "max-content";
+        } else {
+            gridEl.style.gridTemplateColumns = `repeat(${tierData.length}, 1fr)`;
+            gridEl.style.width = "";
+        }
+
         tierData.forEach((col) => {
             const tier = document.createElement("div");
             tier.className = "tier";
@@ -748,11 +757,16 @@
                     const scienceCount = girScience.length; // 4
                     const hassCount = girHass.length; // 5
                     const total = scienceCount + hassCount;
-                    const sciencePct = (scienceCount / total) * 100;
-                    const hassPct = (hassCount / total) * 100;
-                    // First block is Science Core in markup
-                    blocks[0].style.flex = `0 0 ${sciencePct}%`;
-                    blocks[1].style.flex = `0 0 ${hassPct}%`;
+                    const isWide = window.innerWidth > 800;
+                    if (isWide) {
+                        const sciencePct = (scienceCount / total) * 100;
+                        const hassPct = (hassCount / total) * 100;
+                        // First block is Science Core in markup
+                        blocks[0].style.flex = `0 0 ${sciencePct}%`;
+                        blocks[1].style.flex = `0 0 ${hassPct}%`;
+                    } else {
+                        blocks.forEach((b) => (b.style.flex = "0 0 auto"));
+                    }
                 }
             }
         })

--- a/script.js
+++ b/script.js
@@ -347,7 +347,7 @@
         const isGir = gridEl.closest(".gir-board");
         if (isGir) {
             gridEl.style.gridTemplateColumns = `repeat(${tierData.length}, minmax(150px, 1fr))`;
-            gridEl.style.width = "max-content";
+            gridEl.style.width = "";
         } else {
             gridEl.style.gridTemplateColumns = `repeat(${tierData.length}, 1fr)`;
             gridEl.style.width = "";
@@ -744,31 +744,6 @@
                 positionPlan();
             });
 
-            // Ensure HASS vs Science Core blocks have proportional widths so tier columns match
-            const girSection = document.querySelector(".section.gir");
-            const girRows = girSection
-                ? girSection.querySelectorAll(".section-row")
-                : null;
-            if (girRows && girRows[0]) {
-                const blocks = girRows[0].querySelectorAll(
-                    ".gir-block, .section-block"
-                );
-                if (blocks.length >= 2) {
-                    const scienceCount = girScience.length; // 4
-                    const hassCount = girHass.length; // 5
-                    const total = scienceCount + hassCount;
-                    const isWide = window.innerWidth > 800;
-                    if (isWide) {
-                        const sciencePct = (scienceCount / total) * 100;
-                        const hassPct = (hassCount / total) * 100;
-                        // First block is Science Core in markup
-                        blocks[0].style.flex = `0 0 ${sciencePct}%`;
-                        blocks[1].style.flex = `0 0 ${hassPct}%`;
-                    } else {
-                        blocks.forEach((b) => (b.style.flex = "0 0 auto"));
-                    }
-                }
-            }
         })
         .catch((err) => {
             console.warn("Could not merge classes.json:", err);

--- a/styles.css
+++ b/styles.css
@@ -131,8 +131,10 @@ input[type="search"] {
     padding: 32px;
     cursor: default;
 }
-.stage > h2 {
-    margin: 0 0 8px;
+.stage > h2,
+.gir-block > h3 {
+    margin: 0 0 6px;
+    font-family: "Courier New", monospace;
 }
 .board {
     position: relative;
@@ -160,15 +162,19 @@ input[type="search"] {
 .section-row,
 .gir-row {
     display: flex;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     gap: 32px;
     margin-bottom: 32px;
-    overflow-x: auto;
 }
 
 .section-block,
 .gir-block {
-    flex: 1;
+    flex: 1 1 300px;
+    min-width: 0;
+}
+
+.gir-board {
+    overflow-x: auto;
 }
 .grid {
     display: grid;

--- a/styles.css
+++ b/styles.css
@@ -132,7 +132,8 @@ input[type="search"] {
     cursor: default;
 }
 .stage > h2 {
-    margin: 0 0 12px;
+    margin: 0 0 8px;
+    font-family: "Courier New", Courier, monospace;
 }
 .board {
     position: relative;
@@ -146,6 +147,10 @@ input[type="search"] {
     );
     border: 1px solid rgba(255, 255, 255, 0.06);
     box-shadow: var(--shadow);
+}
+
+.gir-container {
+    padding: 24px;
 }
 
 .section {

--- a/styles.css
+++ b/styles.css
@@ -133,7 +133,6 @@ input[type="search"] {
 }
 .stage > h2 {
     margin: 0 0 8px;
-    font-family: "Courier New", Courier, monospace;
 }
 .board {
     position: relative;


### PR DESCRIPTION
## Summary
- Wrap GIR section in a stage and board container to match other sections
- Tighten section heading spacing and use Courier New for a rigid look
- Add padding to new GIR container for consistent layout

## Testing
- `node --check script.js`
- `python -m py_compile scrape_mit_catalog.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7ac57b198832da5c06b2b29257029