### PR TITLE
Equalize grid row heights for consistent node sizing

### DIFF
--- a/script.js
+++ b/script.js
@@ -363,13 +363,31 @@
         });
     }
 
-    function equalizeRowHeights(gridEl) {
+    function equalizeRowSizes(gridEl) {
         const tiers = Array.from(gridEl.querySelectorAll(".tier"));
+
+        // reset existing inline sizing
         tiers.forEach((tier) => {
             tier.querySelectorAll(".node").forEach((node) => {
                 node.style.height = "";
+                node.style.width = "";
             });
         });
+
+        // equalize widths across all nodes in the grid
+        let maxWidth = 0;
+        tiers.forEach((tier) => {
+            tier.querySelectorAll(".node").forEach((node) => {
+                if (node.offsetWidth > maxWidth) maxWidth = node.offsetWidth;
+            });
+        });
+        tiers.forEach((tier) => {
+            tier.querySelectorAll(".node").forEach((node) => {
+                node.style.width = `${maxWidth}px`;
+            });
+        });
+
+        // equalize heights row by row
         const maxRows = Math.max(
             0,
             ...tiers.map((t) => t.querySelectorAll(".node").length)
@@ -386,10 +404,10 @@
         }
     }
 
-    function equalizeAllRows() {
+    function equalizeAllSizes() {
         document
             .querySelectorAll(".grid")
-            .forEach((gridEl) => equalizeRowHeights(gridEl));
+            .forEach((gridEl) => equalizeRowSizes(gridEl));
     }
     function layout(gridEl, tierData) {
         gridEl.innerHTML = "";
@@ -399,7 +417,7 @@
             gridEl.style.gridTemplateColumns = `repeat(${tierData.length}, minmax(150px, 1fr))`;
             gridEl.style.width = "";
         } else {
-            gridEl.style.gridTemplateColumns = `repeat(${tierData.length}, 1fr)`;
+            gridEl.style.gridTemplateColumns = `repeat(${tierData.length}, minmax(0, 1fr))`;
             gridEl.style.width = "";
         }
 
@@ -855,7 +873,7 @@
             }
         });
 
-        equalizeAllRows();
+        equalizeAllSizes();
     }
 
     // Apply responsive sizing on load and resize

--- a/script.js
+++ b/script.js
@@ -362,6 +362,35 @@
             container.appendChild(renderTagIcons(nodes[id].tags || []));
         });
     }
+
+    function equalizeRowHeights(gridEl) {
+        const tiers = Array.from(gridEl.querySelectorAll(".tier"));
+        tiers.forEach((tier) => {
+            tier.querySelectorAll(".node").forEach((node) => {
+                node.style.height = "";
+            });
+        });
+        const maxRows = Math.max(
+            0,
+            ...tiers.map((t) => t.querySelectorAll(".node").length)
+        );
+        for (let i = 0; i < maxRows; i++) {
+            const rowNodes = tiers
+                .map((t) => t.querySelectorAll(".node")[i])
+                .filter(Boolean);
+            let max = 0;
+            rowNodes.forEach((n) => {
+                if (n.offsetHeight > max) max = n.offsetHeight;
+            });
+            rowNodes.forEach((n) => (n.style.height = `${max}px`));
+        }
+    }
+
+    function equalizeAllRows() {
+        document
+            .querySelectorAll(".grid")
+            .forEach((gridEl) => equalizeRowHeights(gridEl));
+    }
     function layout(gridEl, tierData) {
         gridEl.innerHTML = "";
 
@@ -400,6 +429,7 @@
             }
             gridEl.appendChild(tier);
         });
+
     }
 
     function positionAll() {
@@ -759,7 +789,8 @@
             // Update rendered tag rows now that tags are available
             updateRenderedTags();
 
-            // Position everything after layout
+            // Apply responsive sizing and position after tags render
+            applyResponsiveSizing();
             requestAnimationFrame(() => {
                 positionAll();
                 positionPlan();
@@ -779,6 +810,7 @@
             layout(document.getElementById("gir-lab"), girLab);
             layout(document.getElementById("gir-pe"), girPE);
             layout(document.getElementById("gir-rest"), girRest);
+            applyResponsiveSizing();
             requestAnimationFrame(() => {
                 positionAll();
                 positionPlan();
@@ -822,6 +854,8 @@
                 if (code) code.style.marginBottom = "";
             }
         });
+
+        equalizeAllRows();
     }
 
     // Apply responsive sizing on load and resize


### PR DESCRIPTION
## Summary
- add row height equalization to keep nodes in the same grid row the same size
- run responsive sizing after tag rendering so mobile view stays consistent

## Testing
- `node --check script.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7de493ea0832da05cd0504b516ecf